### PR TITLE
fix: rename website_domain to be clearer

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,6 @@ module "s3" {
   suffix = local.suffix
 
   encryption_key_arn = coalesce(var.kms_arn, module.kms[0].key_arn)
-  cors_hostname      = var.website_domain
+  cors_hostname      = var.website_endpoint
   retain_on_destroy  = var.s3_retain_on_destroy
 }

--- a/variables.tf
+++ b/variables.tf
@@ -116,9 +116,9 @@ variable "rds_backup_retention_period" {
   default     = 3
 }
 
-variable "website_domain" {
+variable "website_endpoint" {
   type        = string
-  description = "The hostname of the Spacelift website. Should include protocol (https://). This is being used for state uploads during Stack creations. Example: https://spacelift.mycorp.com. If this isn't known at the time of the deployment, it can be set later."
+  description = "The endpoint of the Spacelift website. Should include protocol (https://). This is being used for state uploads during Stack creations. Example: https://spacelift.mycorp.com. If this isn't known at the time of the deployment, it can be set later."
   default     = ""
 }
 


### PR DESCRIPTION
I'm renaming the `website_domain` variable to `website_endpoint` to make it more obvious it should include the protocol.