### PR TITLE
feat: add ecr_force_delete option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "ecr" {
   kms_key_arn                = coalesce(var.kms_arn, module.kms[0].key_arn)
   suffix                     = local.suffix
   number_of_images_to_retain = var.number_of_images_to_retain
+  ecr_force_delete           = var.ecr_force_delete
 }
 
 module "network" {

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,5 +1,6 @@
 resource "aws_ecr_repository" "backend" {
-  name = "spacelift-backend-${var.suffix}"
+  name         = "spacelift-backend-${var.suffix}"
+  force_delete = var.ecr_force_delete
 
   encryption_configuration {
     encryption_type = "KMS"
@@ -32,7 +33,8 @@ resource "aws_ecr_lifecycle_policy" "backend" {
 }
 
 resource "aws_ecr_repository" "launcher" {
-  name = "spacelift-launcher-${var.suffix}"
+  name         = "spacelift-launcher-${var.suffix}"
+  force_delete = var.ecr_force_delete
 
   encryption_configuration {
     encryption_type = "KMS"

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -12,3 +12,8 @@ variable "kms_key_arn" {
   type        = string
   description = "ARN of the KMS key to use for encrypting the ECR repository."
 }
+
+variable "ecr_force_delete" {
+  type        = bool
+  description = "Whether to force delete the ECRs, even if they contain images."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -126,3 +126,9 @@ variable "number_of_images_to_retain" {
   description = "Number of Docker images to retain in ECR repositories. Default is 5. If set to 0, no images will be cleaned up."
   default     = 5
 }
+
+variable "ecr_force_delete" {
+  type        = bool
+  description = "Whether to force delete the ECRs, even if they contain images."
+  default     = false
+}


### PR DESCRIPTION
This is to make it easier to destroy the infra even if images have already been pushed to the repositories.