### PR TITLE
feat: adjust module to support deploying to EKS

### DIFF
--- a/examples/custom-vpc/main.tf
+++ b/examples/custom-vpc/main.tf
@@ -4,9 +4,18 @@ resource "random_uuid" "suffix" {
 module "network" {
   source = "../../modules/network"
 
-  suffix          = lower(substr(random_uuid.suffix.id, 0, 5))
-  create_database = true
-  vpc_cidr_block  = "10.0.0.0/18"
+  suffix               = lower(substr(random_uuid.suffix.id, 0, 5))
+  create_database      = true
+  vpc_cidr_block       = "10.0.0.0/18"
+  enable_dns_hostnames = false
+
+  private_subnet_tags = {
+    "subnet-role" = "private"
+  }
+
+  public_subnet_tags = {
+    "subnet-role" = "public"
+  }
 }
 
 module "spacelift" {

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,8 @@ resource "random_uuid" "suffix" {
 locals {
   suffix                 = coalesce(lower(var.unique_suffix), lower(substr(random_uuid.suffix.id, 0, 5))) # Certain resources (subnet group, rds) require all lowercase names
   uploads_bucket_url     = "https://${module.s3.uploads_bucket_name}.s3.${var.region}.${data.aws_partition.current.dns_suffix}"
-  database_url           = var.create_database ? format("postgres://%s:%s@%s:5432/spacelift?statement_cache_capacity=0", var.rds_username, urlencode(module.rds[0].db_password), module.rds[0].cluster_endpoint) : null
-  database_read_only_url = var.create_database ? format("postgres://%s:%s@%s:5432/spacelift?statement_cache_capacity=0", var.rds_username, urlencode(module.rds[0].db_password), module.rds[0].reader_endpoint) : null
+  database_url           = var.create_database ? format("postgres://%s:%s@%s:5432/spacelift?statement_cache_capacity=0", var.rds_username, urlencode(module.rds[0].db_password), module.rds[0].cluster_endpoint) : ""
+  database_read_only_url = var.create_database ? format("postgres://%s:%s@%s:5432/spacelift?statement_cache_capacity=0", var.rds_username, urlencode(module.rds[0].db_password), module.rds[0].reader_endpoint) : ""
   kms_arn                = var.kms_arn != null && var.kms_arn != "" ? var.kms_arn : module.kms[0].key_arn
 }
 
@@ -32,9 +32,12 @@ module "network" {
   source = "./modules/network"
   count  = var.create_vpc ? 1 : 0
 
-  suffix          = local.suffix
-  create_database = var.create_database
-  vpc_cidr_block  = var.vpc_cidr_block
+  suffix               = local.suffix
+  create_database      = var.create_database
+  vpc_cidr_block       = var.vpc_cidr_block
+  enable_dns_hostnames = var.enable_dns_hostnames
+  public_subnet_tags   = var.public_subnet_tags
+  private_subnet_tags  = var.private_subnet_tags
 }
 
 module "rds" {

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -7,7 +7,7 @@ data "aws_availability_zones" "available" {}
 
 resource "aws_vpc" "spacelift_vpc" {
   cidr_block           = var.vpc_cidr_block
-  enable_dns_hostnames = false
+  enable_dns_hostnames = var.enable_dns_hostnames
   enable_dns_support   = true
 
   tags = {
@@ -23,9 +23,9 @@ resource "aws_subnet" "private_subnets" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
   map_public_ip_on_launch = false
 
-  tags = {
+  tags = merge(var.private_subnet_tags, {
     Name = "Spacelift Private Subnet (${var.suffix} - ${count.index})"
-  }
+  })
 }
 
 resource "aws_subnet" "public_subnets" {
@@ -36,7 +36,7 @@ resource "aws_subnet" "public_subnets" {
   availability_zone       = element(data.aws_availability_zones.available.names, count.index)
   map_public_ip_on_launch = false
 
-  tags = {
+  tags = merge(var.public_subnet_tags, {
     Name = "Spacelift Public Subnet (${var.suffix} - ${count.index})"
-  }
+  })
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -12,3 +12,17 @@ variable "vpc_cidr_block" {
   description = "The CIDR block to use for the VPC created for Spacelift"
 }
 
+variable "enable_dns_hostnames" {
+  type        = bool
+  description = "Whether DNS hostnames should be enabled on the VPC or not."
+}
+
+variable "public_subnet_tags" {
+  type        = map(string)
+  description = "Custom tags to apply to the public subnets."
+}
+
+variable "private_subnet_tags" {
+  type        = map(string)
+  description = "Custom tags to apply to the private subnets."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,24 @@ variable "vpc_cidr_block" {
   default     = "10.0.0.0/18"
 }
 
+variable "enable_dns_hostnames" {
+  type        = bool
+  description = "Whether DNS hostnames should be enabled on the VPC or not."
+  default     = false
+}
+
+variable "public_subnet_tags" {
+  type        = map(string)
+  description = "Custom tags to apply to the public subnets."
+  default     = {}
+}
+
+variable "private_subnet_tags" {
+  type        = map(string)
+  description = "Custom tags to apply to the private subnets."
+  default     = {}
+}
+
 variable "rds_subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs to use for the RDS instances. If create_vpc is false, this must be provided."


### PR DESCRIPTION
I've made the following changes to allow the module to be used for our EKS quick start guide:

- Added support for enabling DNS hostnames on the VPC.
- Added support for tagging the public and private subnets. This is so that we can add certain tags needed for EKS to know which subnets it can use, along with what subnets to place load balancers in.