### PR TITLE
fix: tag for NAT Gateway IP

### DIFF
--- a/modules/network/nat_gateway.tf
+++ b/modules/network/nat_gateway.tf
@@ -2,7 +2,7 @@ resource "aws_eip" "eips" {
   count = 3
 
   tags = {
-    Name = "Spacelift Load Balancer IP (${var.suffix} - ${count.index})"
+    Name = "Spacelift NAT Gateway IP (${var.suffix} - ${count.index})"
   }
 }
 


### PR DESCRIPTION
The name tag is a little misleading because the IP is associated with the NAT Gateways, not the Load Balancer.