### PR TITLE
feat: update the module to support custom S3 expirations

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 # Note: the module version here is just used to run tests via the Spacelift private module registry.
 # The value can be changed as needed and doesn't need to match the tagged module version.
-module_version: "0.0.1"
+module_version: "0.0.2"
 
 tests:
   - name: Custom VPC

--- a/main.tf
+++ b/main.tf
@@ -83,8 +83,8 @@ module "s3" {
 
   suffix = local.suffix
 
-  bucket_names       = var.s3_bucket_names
-  kms_master_key_arn = local.kms_arn
-  cors_hostname      = var.website_endpoint
-  retain_on_destroy  = var.s3_retain_on_destroy
+  bucket_configuration = var.s3_bucket_configuration
+  kms_master_key_arn   = local.kms_arn
+  cors_hostname        = var.website_endpoint
+  retain_on_destroy    = var.s3_retain_on_destroy
 }

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,16 +1,27 @@
 locals {
   bucket_names = {
-    "binaries" : var.bucket_names != null ? var.bucket_names.binaries : "spacelift-binaries-${var.suffix}",
-    "deliveries" : var.bucket_names != null ? var.bucket_names.deliveries : "spacelift-deliveries-${var.suffix}",
-    "large-queue" : var.bucket_names != null ? var.bucket_names.large_queue : "spacelift-large-queue-messages-${var.suffix}",
-    "metadata" : var.bucket_names != null ? var.bucket_names.metadata : "spacelift-metadata-${var.suffix}",
-    "modules" : var.bucket_names != null ? var.bucket_names.modules : "spacelift-modules-${var.suffix}",
-    "policy" : var.bucket_names != null ? var.bucket_names.policy : "spacelift-policy-inputs-${var.suffix}",
-    "run-logs" : var.bucket_names != null ? var.bucket_names.run_logs : "spacelift-run-logs-${var.suffix}",
-    "states" : var.bucket_names != null ? var.bucket_names.states : "spacelift-states-${var.suffix}",
-    "uploads" : var.bucket_names != null ? var.bucket_names.uploads : "spacelift-uploads-${var.suffix}",
-    "user-uploads" : var.bucket_names != null ? var.bucket_names.user_uploads : "spacelift-user-uploaded-workspaces-${var.suffix}",
-    "workspace" : var.bucket_names != null ? var.bucket_names.workspace : "spacelift-workspace-${var.suffix}",
+    "binaries" : var.bucket_configuration != null ? var.bucket_configuration.binaries.name : "spacelift-binaries-${var.suffix}",
+    "deliveries" : var.bucket_configuration != null ? var.bucket_configuration.deliveries.name : "spacelift-deliveries-${var.suffix}",
+    "large-queue" : var.bucket_configuration != null ? var.bucket_configuration.large_queue.name : "spacelift-large-queue-messages-${var.suffix}",
+    "metadata" : var.bucket_configuration != null ? var.bucket_configuration.metadata.name : "spacelift-metadata-${var.suffix}",
+    "modules" : var.bucket_configuration != null ? var.bucket_configuration.modules.name : "spacelift-modules-${var.suffix}",
+    "policy" : var.bucket_configuration != null ? var.bucket_configuration.policy.name : "spacelift-policy-inputs-${var.suffix}",
+    "run-logs" : var.bucket_configuration != null ? var.bucket_configuration.run_logs.name : "spacelift-run-logs-${var.suffix}",
+    "states" : var.bucket_configuration != null ? var.bucket_configuration.states.name : "spacelift-states-${var.suffix}",
+    "uploads" : var.bucket_configuration != null ? var.bucket_configuration.uploads.name : "spacelift-uploads-${var.suffix}",
+    "user-uploads" : var.bucket_configuration != null ? var.bucket_configuration.user_uploads.name : "spacelift-user-uploaded-workspaces-${var.suffix}",
+    "workspace" : var.bucket_configuration != null ? var.bucket_configuration.workspace.name : "spacelift-workspace-${var.suffix}",
+  }
+
+  bucket_expirations = {
+    "deliveries" : var.bucket_configuration != null ? var.bucket_configuration.deliveries.expiration_days : 1,
+    "large-queue" : var.bucket_configuration != null ? var.bucket_configuration.large_queue.expiration_days : 2,
+    "metadata" : var.bucket_configuration != null ? var.bucket_configuration.metadata.expiration_days : 2,
+    "policy" : var.bucket_configuration != null ? var.bucket_configuration.policy.expiration_days : 120,
+    "run-logs" : var.bucket_configuration != null ? var.bucket_configuration.run_logs.expiration_days : 60,
+    "uploads" : var.bucket_configuration != null ? var.bucket_configuration.uploads.expiration_days : 1,
+    "user-uploads" : var.bucket_configuration != null ? var.bucket_configuration.user_uploads.expiration_days : 1,
+    "workspace" : var.bucket_configuration != null ? var.bucket_configuration.workspace.expiration_days : 90,
   }
 }
 
@@ -68,7 +79,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "deliveries" {
     }
 
     expiration {
-      days = 1
+      days = local.bucket_expirations["deliveries"]
     }
   }
 }
@@ -105,7 +116,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "large_queue_messages" {
     }
 
     expiration {
-      days = 2
+      days = local.bucket_expirations["large-queue"]
     }
   }
 }
@@ -151,7 +162,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "metadata" {
     }
 
     expiration {
-      days = 2
+      days = local.bucket_expirations["metadata"]
     }
   }
 }
@@ -217,7 +228,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "policy_inputs" {
     }
 
     expiration {
-      days = 120
+      days = local.bucket_expirations["policy"]
     }
   }
 }
@@ -281,7 +292,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "run_logs" {
     }
 
     expiration {
-      days = 60
+      days = local.bucket_expirations["run-logs"]
     }
   }
 }
@@ -393,7 +404,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "uploads" {
     }
 
     expiration {
-      days = 1
+      days = local.bucket_expirations["uploads"]
     }
   }
 }
@@ -437,7 +448,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "user_uploads" {
     }
 
     expiration {
-      days = 1
+      days = local.bucket_expirations["user-uploads"]
     }
   }
 }
@@ -502,7 +513,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "workspaces" {
     }
 
     expiration {
-      days = 90
+      days = local.bucket_expirations["workspace"]
     }
   }
 }

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -18,18 +18,18 @@ variable "retain_on_destroy" {
   description = "Whether to retain the bucket and its contents when destroyed. The objects can be recovered."
 }
 
-variable "bucket_names" {
+variable "bucket_configuration" {
   type = object({
-    binaries     = string
-    deliveries   = string
-    large_queue  = string
-    metadata     = string
-    modules      = string
-    policy       = string
-    run_logs     = string
-    states       = string
-    uploads      = string
-    user_uploads = string
-    workspace    = string
+    binaries     = object({ name = string, expiration_days = number })
+    deliveries   = object({ name = string, expiration_days = number })
+    large_queue  = object({ name = string, expiration_days = number })
+    metadata     = object({ name = string, expiration_days = number })
+    modules      = object({ name = string, expiration_days = number })
+    policy       = object({ name = string, expiration_days = number })
+    run_logs     = object({ name = string, expiration_days = number })
+    states       = object({ name = string, expiration_days = number })
+    uploads      = object({ name = string, expiration_days = number })
+    user_uploads = object({ name = string, expiration_days = number })
+    workspace    = object({ name = string, expiration_days = number })
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -184,8 +184,8 @@ variable "rds_preferred_backup_window" {
 
 variable "rds_backup_retention_period" {
   type        = number
-  description = "The number of days for which automated backups are retained. Default is 3."
-  default     = 3
+  description = "The number of days for which automated backups are retained. Default is 5."
+  default     = 5
 }
 
 variable "website_endpoint" {
@@ -210,21 +210,21 @@ variable "security_group_names" {
   default     = null
 }
 
-variable "s3_bucket_names" {
+variable "s3_bucket_configuration" {
   type = object({
-    binaries     = string
-    deliveries   = string
-    large_queue  = string
-    metadata     = string
-    modules      = string
-    policy       = string
-    run_logs     = string
-    states       = string
-    uploads      = string
-    user_uploads = string
-    workspace    = string
+    binaries     = object({ name = string, expiration_days = number })
+    deliveries   = object({ name = string, expiration_days = number })
+    large_queue  = object({ name = string, expiration_days = number })
+    metadata     = object({ name = string, expiration_days = number })
+    modules      = object({ name = string, expiration_days = number })
+    policy       = object({ name = string, expiration_days = number })
+    run_logs     = object({ name = string, expiration_days = number })
+    states       = object({ name = string, expiration_days = number })
+    uploads      = object({ name = string, expiration_days = number })
+    user_uploads = object({ name = string, expiration_days = number })
+    workspace    = object({ name = string, expiration_days = number })
   })
-  description = "S3 bucket names for Spacelift resources."
+  description = "Custom configuration for S3 buckets."
   default     = null
 }
 


### PR DESCRIPTION
Our existing CloudFormation approach allows customers to adjust the retention periods of certain buckets. I've updated the module to allow retention periods to be passed in to help with v2 -> v3 migrations.

I also noticed that the default value for the `rds_backup_retention_period` didn't match the current v2 approach, so I've increased it to match.