### PR TITLE
Allow AWS provider v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check out the [Terraform](https://developer.hashicorp.com/terraform/language/bac
 
 ```hcl
 module "spacelift" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.1.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.4.0"
 
   region       = "eu-west-1"
 }
@@ -47,7 +47,7 @@ This deploys the KMS keys, network stack (VPC, subnets, security groups), RDS cl
 
 ```hcl
 module "spacelift" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.2.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.4.0"
 
   region       = "eu-west-1"
 }
@@ -57,7 +57,7 @@ module "spacelift" {
 
 ```hcl
 module "spacelift" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.2.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.4.0"
 
   region       = "eu-west-1"
 
@@ -73,7 +73,7 @@ If `create_vpc` is `false`, you must provide `rds_subnet_ids` and `rds_security_
 
 ```hcl
 module "spacelift" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.2.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.4.0"
 
   region       = "eu-west-1"
 

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "< 7.0"
     }
 
     random = {


### PR DESCRIPTION
AWS Provider v6.0.0 was just released yesterday and we seem to be 100% compatible with it, so let people use it.