### PR TITLE
add rds_cluster_identifier output

### DIFF
--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,3 +1,8 @@
+output "cluster_identifier" {
+  description = "Name of the RDS cluster."
+  value       = aws_rds_cluster.db_cluster.cluster_identifier
+}
+
 output "cluster_resource_id" {
   description = "Cluster resource ID of the RDS cluster."
   value       = aws_rds_cluster.db_cluster.cluster_resource_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,6 +63,11 @@ output "vpc_id" {
   description = "ID of the VPC. It will be null if create_vpc is false."
 }
 
+output "rds_cluster_identifier" {
+  description = "Name of the RDS cluster."
+  value       =  var.create_database ? module.rds[0].cluster_identifier : null
+}
+
 output "rds_cluster_arn" {
   description = "ARN of the RDS cluster. Will be null if create_database is false."
   value       = var.create_database ? module.rds[0].cluster_arn : null


### PR DESCRIPTION
add `rds_cluster_identifier` to output, e.g. in order to allow terraforming CloudWatch dashboard