### PR TITLE
feat: add IoT topic rule for iotcore MQTT broker type

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,4 +100,6 @@ module "sqs" {
   count  = var.create_sqs ? 1 : 0
 
   kms_master_key_arn = local.kms_arn
+  mqtt_broker_type   = var.mqtt_broker_type
+  region             = var.region
 }

--- a/modules/sqs/iot.tf
+++ b/modules/sqs/iot.tf
@@ -1,0 +1,63 @@
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "iot_message_sender" {
+  count = var.mqtt_broker_type == "iotcore" ? 1 : 0
+
+  name = "spacelift-iot-${var.region}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "iot.${data.aws_partition.current.dns_suffix}"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "iot_message_sender" {
+  count = var.mqtt_broker_type == "iotcore" ? 1 : 0
+
+  name = "allow-iot-sqs-sending"
+  role = aws_iam_role.iot_message_sender[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:GenerateDataKey*"
+        ]
+        Resource = var.kms_master_key_arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = "sqs:SendMessage"
+        Resource = aws_sqs_queue.iot.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iot_topic_rule" "spacelift" {
+  count = var.mqtt_broker_type == "iotcore" ? 1 : 0
+
+  name        = "spacelift"
+  enabled     = true
+  sql         = "SELECT *, Timestamp() as timestamp, topic(3) as worker_pool_ulid, topic(4) as worker_ulid FROM 'spacelift/writeonly/#'"
+  sql_version = "2016-03-23"
+  description = "Send all messages published in the spacelift namespace to the ${aws_sqs_queue.iot.name}"
+
+  sqs {
+    role_arn   = aws_iam_role.iot_message_sender[0].arn
+    queue_url  = aws_sqs_queue.iot.url
+    use_base64 = true
+  }
+}

--- a/modules/sqs/variables.tf
+++ b/modules/sqs/variables.tf
@@ -2,3 +2,14 @@ variable "kms_master_key_arn" {
   type        = string
   description = "ARN of the KMS master key to use for SQS queue encryption."
 }
+
+variable "mqtt_broker_type" {
+  type        = string
+  description = "The type of MQTT broker to use. Can be 'builtin' or 'iotcore'."
+  default     = "builtin"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region, used for naming the IoT IAM role."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "create_sqs" {
-  type        = bool
-  description = "Whether to create the SQS queues for Spacelift."
-  default     = false
-}
-
 variable "region" {
   type        = string
   description = "AWS region to deploy resources."
@@ -13,6 +7,23 @@ variable "unique_suffix" {
   type        = string
   description = "A unique suffix to append to resource names. Ideally passed from the terraform-aws-spacelift-selfhosted module's outputs."
   default     = ""
+}
+
+variable "create_sqs" {
+  type        = bool
+  description = "Whether to create the SQS queues for Spacelift."
+  default     = false
+}
+
+variable "mqtt_broker_type" {
+  type        = string
+  description = "The type of MQTT broker to use. Can be 'builtin' for the embedded MQTT server, or 'iotcore' for AWS IoT Core."
+  default     = ""
+
+  validation {
+    condition     = contains(["", "builtin", "iotcore"], var.mqtt_broker_type)
+    error_message = "mqtt_broker_type must be either 'builtin' or 'iotcore'."
+  }
 }
 
 variable "kms_arn" {


### PR DESCRIPTION
When using IoT Core as the MQTT broker, worker messages (heartbeats, worker_ready, run_complete) need an `aws_iot_topic_rule` to route from `spacelift/writeonly/#` into the spacelift-iot SQS queue. Without it, messages never reach the drain and runs get stuck after job assignment.

The built-in broker bridges MQTT to SQS internally, but IoT Core depends on this topic rule for that routing - which previously only existed in the SaaS CloudFormation template.