### PR TITLE
feat: allow enabling the RDS Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Check out the [Terraform](https://developer.hashicorp.com/terraform/language/bac
 
 ```hcl
 module "spacelift" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v2.0.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v2.3.0"
 
   region             = "eu-west-1"
-  rds_engine_version = "17.7"
+  rds_engine_version = "18.3"
 }
 ```
 
@@ -53,7 +53,7 @@ module "spacelift" {
   source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted"
 
   region             = "eu-west-1"
-  rds_engine_version = "17.7"
+  rds_engine_version = "18.3"
 }
 ```
 
@@ -68,7 +68,7 @@ module "spacelift" {
   create_vpc             = false
   rds_subnet_ids         = ["subnet-012345abc", "subnet-012345def", "subnet-012345ghi"]
   rds_security_group_ids = ["sg-012345abc"]
-  rds_engine_version     = "17.7"
+  rds_engine_version     = "18.3"
 }
 ```
 
@@ -82,7 +82,7 @@ module "spacelift" {
 
   region       = "eu-west-1"
 
-  rds_engine_version         = "17.7"
+  rds_engine_version         = "18.3"
   rds_instance_configuration = {
     "primary-instance" = {
       instance_identifier = "primary"
@@ -105,7 +105,7 @@ module "spacelift" {
   source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted"
 
   region             = "eu-west-1"
-  rds_engine_version = "17.7"
+  rds_engine_version = "18.3"
 
   s3_bucket_configuration = {
     run_logs = {
@@ -126,6 +126,24 @@ module "spacelift" {
   }
 }
 ```
+
+### Enable the RDS Data API
+
+Set `rds_enable_http_endpoint` to `true` to turn on the [Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) for the cluster. This unlocks the query editor in the RDS console, so you can run SQL against the database straight from the browser. No bastion host, VPN, or local client needed, which is handy for quick inspections and debugging.
+
+```hcl
+module "spacelift" {
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted"
+
+  region             = "eu-west-1"
+  rds_engine_version = "18.3"
+
+  rds_enable_http_endpoint = true
+}
+```
+
+> [!NOTE]
+> The Data API is only available for Aurora Serverless v2 and provisioned clusters in [supported regions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.regions).
 
 ## 🚀 Release
 

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,7 @@ module "rds" {
   backup_retention_period      = var.rds_backup_retention_period
   preferred_backup_window      = var.rds_preferred_backup_window
   apply_immediately            = var.rds_apply_immediately
+  enable_http_endpoint         = var.rds_enable_http_endpoint
 
   subnet_ids         = length(coalesce(var.rds_subnet_ids, [])) > 0 ? var.rds_subnet_ids : values(module.network[0].private_subnet_ids)
   security_group_ids = length(coalesce(var.rds_security_group_ids, [])) > 0 ? var.rds_security_group_ids : [module.network[0].database_security_group_id]

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -55,6 +55,7 @@ resource "aws_rds_cluster" "db_cluster" {
   port                                = 5432
   vpc_security_group_ids              = var.security_group_ids
   iam_database_authentication_enabled = true
+  enable_http_endpoint                = var.enable_http_endpoint
 }
 
 resource "aws_rds_cluster_instance" "db_instance" {

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -120,3 +120,9 @@ variable "apply_immediately" {
   type        = bool
   description = "Whether to apply cluster modifications immediately or during the next maintenance window."
 }
+
+variable "enable_http_endpoint" {
+  type        = bool
+  description = "Whether to enable the Data API (HTTP endpoint) for the RDS cluster. This also unlocks the query editor in the RDS console, letting you run SQL against the database without a bastion or local client. Only available for Aurora Serverless v2 and provisioned clusters in supported regions, see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.regions for the list."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -230,6 +230,12 @@ variable "rds_apply_immediately" {
   default     = true
 }
 
+variable "rds_enable_http_endpoint" {
+  type        = bool
+  description = "Whether to enable the Data API (HTTP endpoint) for the RDS cluster. This also unlocks the query editor in the RDS console, letting you run SQL against the database without a bastion or local client. Only available for Aurora Serverless v2 and provisioned clusters in supported regions, see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.regions for the list."
+  default     = null
+}
+
 variable "website_endpoint" {
   type        = string
   description = "The endpoint of the Spacelift website. Should include protocol (https://). This is being used for state uploads during Stack creations. Example: https://spacelift.mycorp.com."


### PR DESCRIPTION
Exposes an optional `rds_enable_http_endpoint` flag so operators can turn on Aurora's [Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) for the cluster.

The main draw is the **RDS console query editor** it unlocks: you can run plain SQL against the database straight from the browser, with no bastion host or VPN to stand up first. Makes quick inspections and debugging a lot less painful.

## Behaviour

- Plumbed through all layers: root `rds_enable_http_endpoint` → `module.rds` → `enable_http_endpoint` on `aws_rds_cluster`.
- Defaults to `null`, so AWS keeps its own default (disabled) and existing clusters aren't touched.
- README gains an example section emphasizing the no-bastion workflow.

> [!NOTE]
> The Data API is only available for Aurora Serverless v2 and provisioned clusters in [supported regions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html#data-api.regions).